### PR TITLE
[incubator/kafka] Makes persistentVolume configurable

### DIFF
--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.2.13
+version: 0.3.13
 keywords:
 - kafka
 - zookeeper

--- a/incubator/kafka/Chart.yaml
+++ b/incubator/kafka/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Apache Kafka is publish-subscribe messaging rethought as a distributed
   commit log.
 name: kafka
-version: 0.3.13
+version: 0.3.0
 keywords:
 - kafka
 - zookeeper

--- a/incubator/kafka/README.md
+++ b/incubator/kafka/README.md
@@ -51,24 +51,30 @@ This chart includes a ZooKeeper chart as a dependency to the Kafka
 cluster in its `requirement.yaml` by default. The chart can be customized using the
 following configurable parameters:
 
-| Parameter                      | Description                                                                                                                                      | Default                                                    |
-| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------- |
-| `image`                        | Kafka Container image name                                                                                                                       | `solsson/kafka`                                            |
-| `imageTag`                     | Kafka Container image tag                                                                                                                        | `1.0.0`                                                    |
-| `imagePullPolicy`              | Kafka Container pull policy                                                                                                                      | `Always`                                                   |
-| `replicas`                     | Kafka Brokers                                                                                                                                    | `3`                                                        |
-| `component`                    | Kafka k8s selector key                                                                                                                           | `kafka`                                                    |
-| `resources`                    | Kafka resource requests and limits                                                                                                               | `{}`                                                       |
-| `dataDirectory`                | Kafka data directory                                                                                                                             | `/opt/kafka/data`                                          |
-| `logSubPath`                   | Subpath under `dataDirectory` where kafka logs will be placed. `logs/`                                                                           | `logs`                                                     |
-| `affinity`                     | Pod scheduling preferences                                                                                                                       | `{}`                                                       |
-| `storage`                      | Kafka Persistent volume size                                                                                                                     | `1Gi`                                                      |
-| `configurationOverrides`       | `Kafka ` [configuration setting](https://kafka.apache.org/documentation/#brokerconfigs) overrides in the dictionary format `setting.name: value` | `{}`                                                       |
-| `schema-registry.enabled`      | If True, installs Schema Registry Chart                                                                                                          | `false`                                                    |
-| `updateStrategy`               | StatefulSet update strategy to use.                                                                                                              | `{ type: "OnDelete" }`                                     |
-| `zookeeper.enabled`            | If True, installs Zookeeper Chart                                                                                                                | `true`                                                     |
-| `zookeeper.url`                | URL of Zookeeper Cluster (unneeded if installing Zookeeper Chart)                                                                                | `""`                                                       |
-| `zookeeper.port`               | Port of Zookeeper Cluster                                                                                                                        | `2181`                                                     |
+| Parameter                      | Description                                                                                                     | Default                                                    |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------- |
+| `image`                        | Kafka Container image name                                                                                      | `solsson/kafka`                                            |
+| `imageTag`                     | Kafka Container image tag                                                                                       | `1.0.0`                                                    |
+| `imagePullPolicy`              | Kafka Container pull policy                                                                                     | `Always`                                                   |
+| `replicas`                     | Kafka Brokers                                                                                                   | `3`                                                        |
+| `component`                    | Kafka k8s selector key                                                                                          | `kafka`                                                    |
+| `resources`                    | Kafka resource requests and limits                                                                              | `{}`                                                       |
+| `dataDirectory`                | Kafka data directory                                                                                            | `/opt/kafka/data`                                          |
+| `logSubPath`                   | Subpath under `dataDirectory` where kafka logs will be placed. `logs/`                                          | `logs`                                                     |
+| `affinity`                     | Pod scheduling preferences                                                                                      | `{}`                                                       |
+| `storage`                      | Kafka Persistent volume size                                                                                    | `1Gi`                                                      |
+| `configurationOverrides`       | `Kafka ` [configuration setting][brokerconfigs] overrides in the dictionary format                              | `setting.name: value` | `{}`                               |
+| `persistence.enabled`          | Use a PVC to persist data                                                                                       | `true`                                                     |
+| `persistence.existingClaim`    | Provide an existing PersistentVolumeClaim                                                                       | `nil`                                                      |
+| `persistence.size`             | Size of data volume                                                                                             | `1Gi`                                                      |
+| `persistence.mountPath`        | Mount path of data volume                                                                                       | `/opt/kafka/data`                                          |
+| `persistence.storageClass`     | Storage class of backing PVC                                                                                    | `nil`                                                      |
+| `persistence.annotations`      | Persistent Volume annotations                                                                                   | `{}`                                                       |
+| `schema-registry.enabled`      | If True, installs Schema Registry Chart                                                                         | `false`                                                    |
+| `updateStrategy`               | StatefulSet update strategy to use.                                                                             | `{ type: "OnDelete" }`                                     |
+| `zookeeper.enabled`            | If True, installs Zookeeper Chart                                                                               | `true`                                                     |
+| `zookeeper.url`                | URL of Zookeeper Cluster (unneeded if installing Zookeeper Chart)                                               | `""`                                                       |
+| `zookeeper.port`               | Port of Zookeeper Cluster                                                                                       | `2181`                                                     |
 
 Specify parameters using `--set key=value[,key=value]` argument to `helm install`
 
@@ -111,3 +117,5 @@ Where `my-release` is the name of your helm release.
 * Topic creation is not automated
 * Only supports storage options that have backends for persistent volume claims (tested mostly on AWS)
 * Kafka cluster is not accessible via an external endpoint
+
+[brokerconfigs]: https://kafka.apache.org/documentation/#brokerconfigs

--- a/incubator/kafka/README.md
+++ b/incubator/kafka/README.md
@@ -59,10 +59,8 @@ following configurable parameters:
 | `replicas`                     | Kafka Brokers                                                                                                   | `3`                                                        |
 | `component`                    | Kafka k8s selector key                                                                                          | `kafka`                                                    |
 | `resources`                    | Kafka resource requests and limits                                                                              | `{}`                                                       |
-| `dataDirectory`                | Kafka data directory                                                                                            | `/opt/kafka/data`                                          |
-| `logSubPath`                   | Subpath under `dataDirectory` where kafka logs will be placed. `logs/`                                          | `logs`                                                     |
+| `logSubPath`                   | Subpath under `persistence.mountPath` where kafka logs will be placed.                                          | `logs`                                                     |
 | `affinity`                     | Pod scheduling preferences                                                                                      | `{}`                                                       |
-| `storage`                      | Kafka Persistent volume size                                                                                    | `1Gi`                                                      |
 | `configurationOverrides`       | `Kafka ` [configuration setting][brokerconfigs] overrides in the dictionary format                              | `setting.name: value` | `{}`                               |
 | `persistence.enabled`          | Use a PVC to persist data                                                                                       | `true`                                                     |
 | `persistence.existingClaim`    | Provide an existing PersistentVolumeClaim                                                                       | `nil`                                                      |

--- a/incubator/kafka/templates/configmap.yaml
+++ b/incubator/kafka/templates/configmap.yaml
@@ -9,7 +9,7 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 data:
   zookeeper.connect: "{{ template "zookeeper.url" . }}"
-  log.dirs: "{{ printf "%s/%s" .Values.dataDirectory .Values.logSubPath }}"
+  log.dirs: "{{ printf "%s/%s" .Values.persistence.mountPath .Values.logSubPath }}"
 {{- range $configName, $configValue := .Values.configurationOverrides }}
   {{ $configName }}: "{{ $configValue -}}"
 {{- end -}}

--- a/incubator/kafka/templates/pvc.yaml
+++ b/incubator/kafka/templates/pvc.yaml
@@ -1,0 +1,28 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "kafka.fullname" . }}
+  labels:
+    app: {{ template "kafka.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+{{- if .Values.persistence.annotations }}
+  annotations:
+{{ toYaml .Values.persistence.annotations | indent 4 }}
+{{- end }}
+spec:
+  accessModes:
+  - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/incubator/kafka/templates/pvc.yaml
+++ b/incubator/kafka/templates/pvc.yaml
@@ -1,10 +1,10 @@
 {{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
-kind: PersistentVolumeClaim
-apiVersion: v1
+kind: "PersistentVolumeClaim"
+apiVersion: "v1"
 metadata:
-  name: {{ template "kafka.fullname" . }}
+  name: {{ include "kafka.fullname" . | quote }}
   labels:
-    app: {{ template "kafka.fullname" . }}
+    app: {{ include "kafka.fullname" . | quote }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -90,4 +90,4 @@ spec:
           claimName: {{ .Values.persistence.existingClaim | default (include "kafka.fullname" .) }}
         {{- else }}
         emptyDir: {}
-      {{- end }}
+        {{- end }}

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -85,9 +85,9 @@ spec:
           mountPath: {{ .Values.persistence.mountPath | quote }}
       volumes:
       - name: datadir
-      {{- if .Values.persistence.enabled }}
+        {{- if .Values.persistence.enabled }}
         persistentVolumeClaim:
           claimName: {{ .Values.persistence.existingClaim | default (include "kafka.fullname" .) }}
-      {{- else }}
+        {{- else }}
         emptyDir: {}
       {{- end }}

--- a/incubator/kafka/templates/statefulset.yaml
+++ b/incubator/kafka/templates/statefulset.yaml
@@ -82,15 +82,12 @@ spec:
           /etc/confluent/docker/run
         volumeMounts:
         - name: datadir
-          mountPath: "{{ .Values.dataDirectory }}"
-  volumeClaimTemplates:
-  - metadata:
-      name: datadir
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: {{ .Values.storage }}
-      {{- if .Values.storageClass }}
-      storageClassName: {{ .Values.storageClass | quote }}
+          mountPath: {{ .Values.persistence.mountPath | quote }}
+      volumes:
+      - name: datadir
+      {{- if .Values.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.persistence.existingClaim | default (include "kafka.fullname" .) }}
+      {{- else }}
+        emptyDir: {}
       {{- end }}

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -57,7 +57,7 @@ persistence:
   ## A manually managed Persistent Volume and Claim. Requires persistence.enabled: true.
   ## If defined, PVC must be created manually before volume will be bound
   ##
-  #existingClaim: "my-pvc-name"
+  # existingClaim: "my-pvc-name"
 
   ## The size of the PersistentVolume to allocate to each Kafka Pod in the StatefulSet. For
   ## production servers this number should likely be much larger.
@@ -80,7 +80,7 @@ persistence:
 
   ## Custom PVC annotations.
   ##
-  #annotations: {}
+  # annotations: {}
 
 # ------------------------------------------------------------------------------
 # Zookeeper:

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -24,10 +24,6 @@ resources: {}
   # requests:
   #   cpu: 100m
   #   memory: 1024Mi
-  #
-## The size of the persistentVolume to allocate to each Kafka Pod in the StatefulSet. For
-## production servers this number should likely be much larger.
-storage: "1Gi"
 
 ## The StatefulSet Update Strategy which Kafka will use when changes are applied.
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
@@ -36,10 +32,6 @@ updateStrategy:
 
 ## The name of the storage class which the cluster should use.
 # storageClass: default
-
-## The location within the Kafka container where the PV will mount its storage and Kafka will store
-## its logs
-dataDirectory: "/opt/kafka/data"
 
 ## The subpath within the Kafka container's PV where logs will be stored
 ## This is combined with `dataDirectory` above, to create, by default: /opt/kafka/data/logs
@@ -56,6 +48,36 @@ affinity: {}
 ##
 configurationOverrides:
   "offsets.topic.replication.factor": 3
+
+## Persistence configuration. Specify if and how to persist data to a persistent volume.
+##
+persistence:
+  enabled: true
+
+  ## A manually managed Persistent Volume and Claim. Requires persistence.enabled: true.
+  ## If defined, PVC must be created manually before volume will be bound
+  ##
+  # existingClaim:
+
+  ## The size of the PersistentVolume to allocate to each Kafka Pod in the StatefulSet. For
+  ## production servers this number should likely be much larger.
+  ##
+  size: "1Gi"
+
+  ## The location within the Kafka container where the PV will mount its storage and Kafka will store
+  ## its logs
+  mountPath: "/opt/kafka/data"
+
+  ## The storageClass to use for Kafka's PersistentVolume
+  ## - If defined, storageClassName: <storageClass>
+  ## - If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## - If undefined (the default) or set to null, no storageClassName spec is
+  ##     set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##     GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+
+  annotations: {}
 
 # ------------------------------------------------------------------------------
 # Zookeeper:

--- a/incubator/kafka/values.yaml
+++ b/incubator/kafka/values.yaml
@@ -33,8 +33,8 @@ updateStrategy:
 ## The name of the storage class which the cluster should use.
 # storageClass: default
 
-## The subpath within the Kafka container's PV where logs will be stored
-## This is combined with `dataDirectory` above, to create, by default: /opt/kafka/data/logs
+## The subpath within the Kafka container's PV where logs will be stored.
+## This is combined with `persistence.mountPath`, to create, by default: /opt/kafka/data/logs
 logSubPath: "logs"
 
 ## Pod scheduling preferences.
@@ -57,15 +57,16 @@ persistence:
   ## A manually managed Persistent Volume and Claim. Requires persistence.enabled: true.
   ## If defined, PVC must be created manually before volume will be bound
   ##
-  # existingClaim:
+  #existingClaim: "my-pvc-name"
 
   ## The size of the PersistentVolume to allocate to each Kafka Pod in the StatefulSet. For
   ## production servers this number should likely be much larger.
   ##
   size: "1Gi"
 
-  ## The location within the Kafka container where the PV will mount its storage and Kafka will store
-  ## its logs
+  ## The location within the Kafka container where the PV will mount its storage and Kafka will
+  ## store its logs.
+  ##
   mountPath: "/opt/kafka/data"
 
   ## The storageClass to use for Kafka's PersistentVolume
@@ -77,7 +78,9 @@ persistence:
   ##
   # storageClass: "-"
 
-  annotations: {}
+  ## Custom PVC annotations.
+  ##
+  #annotations: {}
 
 # ------------------------------------------------------------------------------
 # Zookeeper:


### PR DESCRIPTION
Follows example from [stable/postgresql](https://github.com/kubernetes/charts/tree/master/stable/postgresql) and makes persistence more highly configurable.

We create Kafka StatefulSets during CI on AWS. Creating a Kafka PVC for each CI run was prohibitively costly - EBS volumes would end up getting stuck very frequently. This change allows us to sidestep the issue by relying on the host volume.